### PR TITLE
More versions

### DIFF
--- a/pg_logplexcollector.go
+++ b/pg_logplexcollector.go
@@ -67,9 +67,9 @@ func processVerMsg(msgInit msgInit, exit exitFn) {
 		exit("couldn't read version string: %v", err)
 	}
 
-	if !(strings.HasPrefix(s, "PG-9.2.") ||
-		strings.HasPrefix(s, "PG-9.3.") ||
-		strings.HasPrefix(s, "PG-9.4.")) ||
+	if !(strings.HasPrefix(s, "PG-9.2") ||
+		strings.HasPrefix(s, "PG-9.3") ||
+		strings.HasPrefix(s, "PG-9.4")) ||
 		!strings.HasSuffix(s, "/logfebe-1") {
 		exit("protocol version not supported: %s", s)
 	}

--- a/pg_logplexcollector.go
+++ b/pg_logplexcollector.go
@@ -68,7 +68,8 @@ func processVerMsg(msgInit msgInit, exit exitFn) {
 	}
 
 	if !(strings.HasPrefix(s, "PG-9.2.") ||
-		strings.HasPrefix(s, "PG-9.3.")) ||
+		strings.HasPrefix(s, "PG-9.3.") ||
+		strings.HasPrefix(s, "PG-9.4.")) ||
 		!strings.HasSuffix(s, "/logfebe-1") {
 		exit("protocol version not supported: %s", s)
 	}

--- a/version_message_test.go
+++ b/version_message_test.go
@@ -20,6 +20,7 @@ var versionCheckTests = []struct {
 	{"PG-7.4.15/logfebe-1", false},
 	{"PG-9.2.2/logfebe-1", true},
 	{"PG-9.3.0/logfebe-1", true},
+	{"PG-9.4.0/logfebe-1", true},
 	{"PG7.4.15/1", false},
 }
 

--- a/version_message_test.go
+++ b/version_message_test.go
@@ -19,8 +19,11 @@ var versionCheckTests = []struct {
 	{"PG-7.4.15/1", false},
 	{"PG-7.4.15/logfebe-1", false},
 	{"PG-9.2.2/logfebe-1", true},
+	{"PG-9.2alpha1/logfebe-1", true},
 	{"PG-9.3.0/logfebe-1", true},
+	{"PG-9.3beta2/logfebe-1", true},
 	{"PG-9.4.0/logfebe-1", true},
+	{"PG-9.4devel/logfebe-1", true},
 	{"PG7.4.15/1", false},
 }
 


### PR DESCRIPTION
Whitelist support 9.4 and alpha / beta / development versions. We may or may not want to start being more relaxed about versioning, but this expands support to working versions without changing the actual policy.
